### PR TITLE
Run ndpresponder without root in systemd service

### DIFF
--- a/ndpresponder.service
+++ b/ndpresponder.service
@@ -3,8 +3,8 @@ Description=ndpresponder
 After=network-online.target
 
 [Service]
-ExecStartPre=+/usr/bin/ip route get 2000::
-ExecStart=+/usr/local/bin/ndpresponder -i eth0 -n 2001:db8:3988:486e:ff2f:add3:31e3:7b00/120
+ExecStartPre=/usr/bin/ip route get 2000::
+ExecStart=/usr/local/bin/ndpresponder -i eth0 -n 2001:db8:3988:486e:ff2f:add3:31e3:7b00/120
 Restart=on-failure
 RestartSec=10s
 CPUAccounting=yes
@@ -13,6 +13,8 @@ ProtectSystem=full
 PrivateTmp=yes
 PrivateDevices=yes
 ProtectHome=yes
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
+DynamicUser=yes
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Instead of running ndpresponder as root, grant CAP_NET_ADMIN and CAP_NET_RAW.

Remove the "+" prefix from the ExecStart paths, as this effectively turns off many hardening options [according to the systemd docs](https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html).